### PR TITLE
fixing issue #47

### DIFF
--- a/scripts/texi2pod.pl
+++ b/scripts/texi2pod.pl
@@ -317,7 +317,7 @@ while(<$inf>) {
 	@columns = ();
 	for $column (split (/\s*\@tab\s*/, $1)) {
 	    # @strong{...} is used a @headitem work-alike
-	    $column =~ s/^\@strong{(.*)}$/$1/;
+	    $column =~ s/^\@strong\{(.*)\}$/$1/;
 	    push @columns, $column;
 	}
 	$_ = "\n=item ".join (" : ", @columns)."\n";


### PR DESCRIPTION
A literal `{ ` or  ` }`  in a regular expression is deprecated and causes a syntax error in Perl version 5.26 when making qemu-nvme. 
This can be fixed by escaping : `\{` or `\}`.
